### PR TITLE
Small changes to add compatibilty with Django 1.8+ 

### DIFF
--- a/flexipage/admin.py
+++ b/flexipage/admin.py
@@ -34,13 +34,13 @@ class FlexiContentInline(StackedDynamicInlineAdmin):
     fk_name = 'page'
     formset = FlexiContentInlineFormset
     extra = 0
-    
+
     class Media:
         js = ('js/admin/save_modelform_onchange.js',)
-        
+
 
 class FlexiPageAdmin(PageAdmin):
     inlines = (FlexiContentInline,)
-    fields = ('')
-    
+
+
 admin.site.register(FlexiPage, FlexiPageAdmin)

--- a/flexipage/utils.py
+++ b/flexipage/utils.py
@@ -1,10 +1,15 @@
 import os
 
 from django.template.loader import get_template
-from django.template import VariableNode
 from django.template.loader_tags import ExtendsNode
 from django.conf import settings
 from django.template.base import TemplateDoesNotExist
+
+try:
+    from django.template.base import VariableNode
+except ImportError:
+    from django.template import VariableNode
+
 
 try:
     FLEXI_VARIABLE_PREFIX = settings.FLEXI_VARIABLE_PREFIX
@@ -45,11 +50,10 @@ def get_template_variables(nodes):
         if extend_node:
             parent_template_path = extend_node.parent_name.var
             try:
-                parent_template = get_template(parent_template_path)
+                parent_template = get_flexi_template(parent_template_path)
             except TemplateDoesNotExist:
                 print 'couldn\'t find template: %s' % parent_template_path
                 continue
-
             return variables + get_template_variables(parent_template.nodelist)
 
     return variables
@@ -67,6 +71,8 @@ def get_flexi_template(template_name):
         template = get_template(template_name)
     except TemplateDoesNotExist:
         template = get_template(os.path.join('flexipage', template_name))
+    if hasattr(template, 'template'): #workaround for Django 1.7+
+        template = template.template
     return template
 
 


### PR DESCRIPTION
Changes in Django 1.8 to support different template engines broke Flexipage.
I made fixed them in an backward compatible way. 
I tested it with  Django 1.6 and Mezzanine 3.1 and Django 1.8 and Mezzanine 4.0.

The hasattr(template, 'template') line is hacky, but i have no idea how i could differ between 2 classes,  where one only exists in Django 1.8, without breaking backwards compatibility. 
